### PR TITLE
Feature/admin creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ Une fois que ces fichiers seront crées, vous pourrez effectuez les migrations v
 `php symfony/bin/console doctrine:migrations:migrate`
 
 
+## Créer un admin
+Pour pouvoir accéder au back-office, il vous faudra un compte ayant les droits d'administration. Vous pouvez entrer la commande :
+
+`php symfony/bin/console app:create-admin <email> [<password>]`
+
+Cela vous créera un compte admin.
+
+L'argument **email** derrière la commande est obligatoire, mais *pas* l'argument **password**. La commande suivante est valide :
+
+`php symfony/bin/console app:create-admin admin@gmail.com`
+
+Dans ce cas, le mot de passe sera tout simplement **admin**.
+
+Vous pourrez ensuite utilisez le compt crée pour vous connecter à l'addresse */admin/login*.
+
+
 ## Lancement
 
 Pour lancer le serveur, allez dans le dossier *symfony*, puis entrez `symfony server:start`

--- a/symfony/config/services.yaml
+++ b/symfony/config/services.yaml
@@ -19,6 +19,10 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+    
+    App\Command\CreateAdminCommand:
+        tags:
+            - { name: 'console.command', command: 'app:create-admin' }
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/symfony/src/Command/CreateAdminCommand.php
+++ b/symfony/src/Command/CreateAdminCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand(
+    name: 'app:create-admin',
+    description: 'Creates a new admin.',
+    hidden: false,
+    aliases: ['app:add-admin']
+)]
+class CreateAdminCommand extends Command
+{
+    protected static $defaultDescription = 'Creates a new admin.';
+
+    private bool $requirePassword;
+
+    public function __construct(private UserPasswordHasherInterface $userPasswordHasher,
+                                private EntityManagerInterface $entityManager,
+                                bool $requirePassword = false)
+    {
+        $this->requirePassword = $requirePassword;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp('This command allows you to create an admin...')
+            ->addArgument('email', InputArgument::REQUIRED, 'The email of the admin.')
+            ->addArgument('password', $this->requirePassword ? InputArgument::REQUIRED : InputArgument::OPTIONAL,
+                          'User password')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        // Empty because doesn't need to be overloaded
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        // Empty because doesn't need to be overloaded
+    }
+
+    protected function execute(InputInterface $input,
+                               OutputInterface $output): int
+    {
+        $password = 'admin';
+        if (!is_null($input->getArgument('password'))) {
+            $password = $input->getArgument('password');
+        }
+        $user = new User();
+        $user->setEmail($input->getArgument('email'));
+        $user->setUsername('admin');
+        $user->setPassword(
+            $this->userPasswordHasher->hashPassword(
+                $user,
+                $password,
+            )
+        );
+        $user->setRoles(["ROLE_USER", "ROLE_ADMIN"]);
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        $output->writeln('L\'admin ' . $input->getArgument('email') . ' a été crée avec succès. Mot de passe : ' . $password);
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
Cette branch ajoute une commande permettant de créer un compte admin en ligne de commande, et donc d'avoir accès facilement au back-office.

Entrez simplement la commande suivante :

`php symfony/bin/console app:create-admin admin@gmail.com`

Et vous créerez un compte admin ayant pour email **admin@gmail.com**, et pour mot de passe **admin**.